### PR TITLE
filter_ally: Skip folders that don't have a name

### DIFF
--- a/filter.php
+++ b/filter.php
@@ -205,6 +205,9 @@ class filter_ally extends moodle_text_filter {
             $folders = $DB->get_records('folder', ['course' => $COURSE->id]);
             $map = [];
             foreach ($folders as $folder) {
+                if (empty($folder->name)) {
+                    continue;
+                }
                 list ($course, $cm) = get_course_and_cm_from_instance($folder->id, 'folder');
                 $map = array_merge($map, $this->get_cm_file_map($cm, 'mod_folder', 'content'));
             }


### PR DESCRIPTION
If an unnamed folder happens to exist in the database, attempting to fetch a cm_info object for it will throw an exception, and the course page will fail to load.
Somehow we have 53 unnamed folder activities in our main Moodle instance at Lancaster University (possibly due to an old bug), so we've had to disable the filter while this is fixed.